### PR TITLE
Changes made so the program could run on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(CheckCXXCompilerFlag)
 # Check for standard to use
 check_cxx_compiler_flag(-std=c++17 HAVE_FLAG_STD_CXX17)
 if(HAVE_FLAG_STD_CXX17)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic --std=c++17")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic --std=c++17 -fPIC")
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic --std=c++1z")
 endif()
@@ -21,22 +21,22 @@ find_package(Boost COMPONENTS program_options REQUIRED)
 
 include_directories(${Boost_INCLUDE_DIRS})
 
-## Dhrystone 
+## Dhrystone
 add_custom_command(OUTPUT dhry/dhry_1.o dhry/dhry_2.o
                    COMMAND make
                    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/dhry
 )
 
 ## CDBoost
-add_executable(cdboost-devstone 
+add_executable(cdboost-devstone
                src/cdboost-devstone.cpp
                src/cdboost-devstone-atomic.hpp
                dhry/dhry_1.o dhry/dhry_2.o
 )
-target_include_directories(cdboost-devstone 
+target_include_directories(cdboost-devstone
                            PUBLIC ${PROJECT_SOURCE_DIR}/simulators/cdboost/include
 )
-target_link_libraries(cdboost-devstone 
+target_link_libraries(cdboost-devstone
                       ${Boost_PROGRAM_OPTIONS_LIBRARY}
 )
 
@@ -79,4 +79,4 @@ enable_testing()
 add_test(NAME Cadmium_generator_LI_3x3
          COMMAND ../test/check_generated_LI_against_ref.sh
          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-) 
+)

--- a/dhry/Makefile
+++ b/dhry/Makefile
@@ -1,7 +1,7 @@
 CC=clang
 CXX=clang++
 
-CFLAGS= -c -O0
+CFLAGS= -c -O0 -fPIC
 LDFLAGS+= -L/usr/local/lib
 
 DHRYSTONE=dhry_1.c dhry_2.c
@@ -9,8 +9,8 @@ DHRYSTONE=dhry_1.c dhry_2.c
 DHRYSTONE_OBJECTS=$(DHRYSTONE:.c=.o)
 
 all: dhrystone
-	
+
 dhrystone: $(DHRYSTONE_OBJECTS)
 
-clean: 
+clean:
 	rm *.o

--- a/run_devstones.sh
+++ b/run_devstones.sh
@@ -26,7 +26,7 @@ done
 for D in `seq 2 1 10`; do
 	for W in `seq 2 1 10`; do
 		echo "Building model W:${W} D:${D}"
-                /usr/bin/time -p \
+                /usr/bin/time -f "%e" \
                 clang++ --std=c++17 -ftemplate-depth=2048 -Isimulators/cadmium/include -Isrc \
                         "${PREFIX}/LI_DEVSTONE_D${D}_W${W}.cpp" dhry/dhry_1.o dhry/dhry_2.o \
                         -o "${PREFIX}/LI_DEVSTONE_D${D}_W${W}"
@@ -36,7 +36,7 @@ done
 for D in `seq 2 1 10`; do
         for W in `seq 2 1 10`; do
                 echo "Running model W:${W} D:${D}"
-                /usr/bin/time -p \
+                /usr/bin/time -f "%e" \
                 "${PREFIX}/LI_DEVSTONE_D${D}_W${W}"
         done
 done

--- a/run_devstones.sh
+++ b/run_devstones.sh
@@ -11,7 +11,7 @@ cp events.txt ${PREFIX}/events.txt
 for D in `seq 2 1 10`; do
 	for W in `seq 2 1 10`; do
 		echo "Generating model W:${W} D:${D}"
- 		Debug/cadmium-devstone   \
+ 		./cadmium-devstone   \
                             --kind=LI    \
                             --width=${W} \
                             --depth=${D} \
@@ -26,19 +26,17 @@ done
 for D in `seq 2 1 10`; do
 	for W in `seq 2 1 10`; do
 		echo "Building model W:${W} D:${D}"
-                /usr/bin/time -l \
-                clang++ --std=c++17 -Isimulators/cadmium/include -Isrc \
+                /usr/bin/time -p \
+                clang++ --std=c++17 -ftemplate-depth=2048 -Isimulators/cadmium/include -Isrc \
                         "${PREFIX}/LI_DEVSTONE_D${D}_W${W}.cpp" dhry/dhry_1.o dhry/dhry_2.o \
                         -o "${PREFIX}/LI_DEVSTONE_D${D}_W${W}"
         done
 done
 # Here we run the generated models and log their executions
-# Here we build the generated models and log their metrics
 for D in `seq 2 1 10`; do
         for W in `seq 2 1 10`; do
                 echo "Running model W:${W} D:${D}"
-                /usr/bin/time -l \
+                /usr/bin/time -p \
                 "${PREFIX}/LI_DEVSTONE_D${D}_W${W}"
         done
 done
-

--- a/setup.sh
+++ b/setup.sh
@@ -21,7 +21,7 @@ if [ -d "$CDBOOST_DIR" ]; then
     git pull
 else
     cd $SIMULATORS_DIR
-    git clone git clone https://scm.gforge.inria.fr/anonscm/git/cdboost/cdboost.git
+    git clone https://scm.gforge.inria.fr/anonscm/git/cdboost/cdboost.git
 fi
 
 #adevs does not have a git repository available
@@ -29,9 +29,9 @@ echo "Fetching adevs"
 ADEVS_DIR="$SIMULATORS_DIR/adevs"
 if [ -d "$ADEVS_DIR" ]; then
     cd "$ADEVS_DIR"
-    git svn fetch
-    git svn rebase
+    svn fetch
+    svn rebase
 else
     cd $SIMULATORS_DIR
-    git svn clone https://svn.code.sf.net/p/adevs/code/trunk adevs
+    svn checkout https://svn.code.sf.net/p/adevs/code/trunk adevs
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -29,9 +29,9 @@ echo "Fetching adevs"
 ADEVS_DIR="$SIMULATORS_DIR/adevs"
 if [ -d "$ADEVS_DIR" ]; then
     cd "$ADEVS_DIR"
-    svn fetch
-    svn rebase
+    git svn fetch
+    git svn rebase
 else
     cd $SIMULATORS_DIR
-    svn checkout https://svn.code.sf.net/p/adevs/code/trunk adevs
+    git svn clone https://svn.code.sf.net/p/adevs/code/trunk adevs
 fi


### PR DESCRIPTION
I had to make some changes to be able to run the program on Linux (Ubuntu 18.04), it looked like it was made on OSX. I think most of them will not break the mac version, but the changes in the run_devstone.sh file maybe will:
- time command doesn't have the -l flag on Linux. In OSX you can use the Linux time (gnu time) with `gtime`
- my `cadmium-devstone` is in the root of the repo, not in Debug/

I don't have access to a mac to try it out but if something breaks we should just add a couple of 
```
if [ "$(uname)" != "Linux" ];
```