### PR TITLE
Command to execute cadmium dynamic models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,14 +52,17 @@ target_link_libraries(cadmium-devstone
 )
 
 ## Reference models used for developing and testing the model generators
-add_executable(cadmium-dynamic-LI33
-               examples/cadmium-dynamic-LI33.cpp
+add_executable(cadmium-dynamic-devstone
+               src/cadmium-dynamic-devstone.cpp
                src/cadmium-devstone-atomic.hpp src/cadmium-event-reader.hpp
                dhry/dhry_1.o dhry/dhry_2.o
                events.txt
 )
-target_include_directories(cadmium-dynamic-LI33
+target_include_directories(cadmium-dynamic-devstone
                            PUBLIC ${PROJECT_SOURCE_DIR}/simulators/cadmium/include
+)
+target_link_libraries(cadmium-dynamic-devstone
+        ${Boost_PROGRAM_OPTIONS_LIBRARY}
 )
 
 ## Reference models used for developing and testing the model generators

--- a/src/cadmium-devstone-atomic.hpp
+++ b/src/cadmium-devstone-atomic.hpp
@@ -63,6 +63,12 @@ public:
         cadmium::get_messages<typename defs::out>(outbag).emplace_back(1);
     }
 
+    constexpr devstone_atomic(int ext_cycles, int int_cycles, TIME time_advance) noexcept
+        : period(time_advance), external_cycles(ext_cycles), internal_cycles(int_cycles){
+        //preparing the output bag, since we return always same message
+        cadmium::get_messages<typename defs::out>(outbag).emplace_back(1);
+    }
+
     // state definition
     using queued_processes=int; //for readability
     using state_type=queued_processes;

--- a/src/cadmium-dynamic-devstone.cpp
+++ b/src/cadmium-dynamic-devstone.cpp
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2019, Juan Lanuza
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <iostream>
+#include <chrono>
+#include <algorithm>
+#include <fstream>
+
+#include <boost/program_options.hpp>
+
+#include <cadmium/engine/pdevs_dynamic_runner.hpp>
+
+#include "dynamic/LI_generator.cpp"
+#include "dynamic/HI_generator.cpp"
+#include "dynamic/HO_generator.cpp"
+#include "dynamic/HOmod_generator.cpp"
+
+namespace po=boost::program_options;
+using hclock=std::chrono::high_resolution_clock;
+using Time=float;
+
+int main(int argc, char* argv[]){
+    auto start = hclock::now();
+
+    // Declare the supported options.
+    po::options_description desc("Allowed options");
+    desc.add_options()
+            ("help", "produce help message")
+            ("kind", po::value<std::string>()->required(), "set kind of devstone: LI, HI, HO or HOmod")
+            ("width", po::value<int>()->required(), "set width of the DEVStone: integer value")
+            ("depth", po::value<int>()->required(), "set depth of the DEVStone: integer value")
+            ("int-cycles", po::value<int>()->required(), "set the Dhrystone cycles to expend in internal transtions: integer value")
+            ("ext-cycles", po::value<int>()->required(), "set the Dhrystone cycles to expend in external transtions: integer value")
+            ("time-advance", po::value<int>()->default_value(1), "set the time expend in external transtions by the Dhrystone in miliseconds: integer value")
+            ;
+
+    po::variables_map vm;
+    try {
+        po::store(po::parse_command_line(argc, argv, desc), vm);
+        po::notify(vm);
+    } catch ( boost::program_options::required_option be ){
+        if (vm.count("help")) {
+            std::cout << desc << "\n";
+            return 0;
+        } else {
+            std::cout << be.what() << std::endl;
+            std::cout << std::endl;
+            std::cout << "for mode information run: " << argv[0] << " --help" << std::endl;
+            return 1;
+        }
+    }
+    std::string kind = vm["kind"].as<std::string>();
+    if (kind.compare("LI") != 0  && kind.compare("HI") != 0 &&
+        kind.compare("HO") != 0 && kind.compare("HOmod") != 0) {
+        std::cout << "The kind needs to be LI, HI, HO or HOmod and received value was: " << kind << std::endl;
+        std::cout << "for mode information run: " << argv[0] << " --help" << std::endl;
+        return 1;
+    }
+
+    int width = vm["width"].as<int>();
+    int depth = vm["depth"].as<int>();
+    int int_cycles = vm["int-cycles"].as<int>();
+    int ext_cycles = vm["ext-cycles"].as<int>();
+    int time_advance = vm["time-advance"].as<int>();
+    //finished processing input
+
+    auto processed_parameters = hclock::now();
+
+    //create models for LI kind
+    // int models_quantity = (width - 1) * (depth - 1) + 1;
+    // int counted_atomic_models=0;
+    // int counted_coupled_models=0;
+
+
+    std::shared_ptr<cadmium::dynamic::modeling::coupled<Time>> TOP_coupled;
+    if (kind.compare("LI") == 0){
+        TOP_coupled = create_LI_model(width,depth, ext_cycles, int_cycles, time_advance);
+    } else if (kind.compare("HI") == 0) {
+        TOP_coupled = create_HI_model(width, depth, ext_cycles, int_cycles, time_advance);
+    } else if (kind.compare("HO") == 0) {
+        TOP_coupled = create_HO_model(width,depth, ext_cycles, int_cycles, time_advance);
+    } else if (kind.compare("HOmod") == 0) {
+        TOP_coupled = create_HOmod_model(width,depth, ext_cycles, int_cycles, time_advance);
+    } else {
+        abort();
+    }
+
+    auto model_built = hclock::now();
+
+    cadmium::dynamic::engine::runner<TIME, cadmium::logger::not_logger> r(TOP_coupled, 0.0);
+
+    auto model_init = hclock::now();
+
+    r.run_until_passivate();
+
+    auto finished_simulation = hclock::now();
+
+    std::cout << "Simulation with params: ";
+
+    for (const auto& it : vm) {
+        std::cout << it.first.c_str() << ": ";
+        auto& value = it.second.value();
+        if (auto v = boost::any_cast<int>(&value))
+            std::cout << *v;
+        else if (auto v = boost::any_cast<std::string>(&value))
+            std::cout << *v;
+        else
+            std::cout << "error";
+        std::cout << " ";
+    }
+
+
+    std::cout << std::endl;
+    std::cout << "time processing arguments: " << std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1>>>( processed_parameters - start).count() << std::endl;
+    std::cout << "time constructing the models: " << std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1>>>( model_built - processed_parameters).count() << std::endl;
+    std::cout << "time initializing the models: " << std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1>>>( model_init - model_built).count() << std::endl;
+    std::cout << "time running simulation: " << std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1>>>( finished_simulation - model_init).count() << std::endl;
+    std::cout << "total time: " << std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1>>>( finished_simulation - start).count() << std::endl;
+}

--- a/src/dynamic/HI_generator.cpp
+++ b/src/dynamic/HI_generator.cpp
@@ -42,31 +42,25 @@
 using TIME = float;
 
 // Ports for coupled models, we use the same in every level
-struct coupled_in_port : public cadmium::in_port<int>{};
-struct coupled_out_port : public cadmium::out_port<int>{};
-cadmium::dynamic::modeling::Ports coupled_in_ports = {typeid(coupled_in_port)};
-cadmium::dynamic::modeling::Ports coupled_out_ports = {typeid(coupled_out_port)};
+struct coupledHI_in_port : public cadmium::in_port<int>{};
+struct coupledHI_out_port : public cadmium::out_port<int>{};
 
-//A configured version of the devstone atomic, we use same configuration in every atomic.
-template<typename T>
-struct configured_atomic_devstone : devstone_atomic<T>{
-    configured_atomic_devstone(){
-        devstone_atomic<T>::period = 1;
-        devstone_atomic<T>::external_cycles = 100;
-        devstone_atomic<T>::internal_cycles = 100;
-    }
-};
-
-
-std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> create_HI_model(uint width, uint depth) {
+std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> create_HI_model(
+        uint width, uint depth, int ext_cycles, int int_cycles, TIME time_advance) {
     // Creates the HI model with the passed parameters
     // Returns a shared_ptr to the TOP model
 
+    auto make_atomic_devstone = [&ext_cycles, &int_cycles, &time_advance](std::string model_id) -> std::shared_ptr<cadmium::dynamic::modeling::model> {
+        return cadmium::dynamic::translate::make_dynamic_atomic_model<devstone_atomic, TIME>(model_id, ext_cycles, int_cycles, time_advance);
+    };
     //Level 0 has always a single model
-    std::shared_ptr<cadmium::dynamic::modeling::model> devstone_atomic_L0_0 = cadmium::dynamic::translate::make_dynamic_atomic_model<configured_atomic_devstone, TIME>("devstone_atomic_L0_0");
+    std::shared_ptr<cadmium::dynamic::modeling::model> devstone_atomic_L0_0 = make_atomic_devstone("devstone_atomic_L0_0");
 
     std::unordered_map<int, cadmium::dynamic::modeling::Models> atomics_by_level;
     std::unordered_map<int, std::shared_ptr<cadmium::dynamic::modeling::model>> coupleds_by_level;
+
+    cadmium::dynamic::modeling::Ports coupled_in_ports = {typeid(coupledHI_in_port)};
+    cadmium::dynamic::modeling::Ports coupled_out_ports = {typeid(coupledHI_out_port)};
 
     for (int level=1; level <= depth; level++) {
 
@@ -76,7 +70,7 @@ std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> create_HI_model(uint 
             //Last level does not have atomics
             for(int idx_atomic=0; idx_atomic < width-1; idx_atomic++) {
                 std::string atomic_name = "devstone_atomic_L" + std::to_string(level) + "_" + std::to_string(idx_atomic);
-                atomics_current_level.push_back(cadmium::dynamic::translate::make_dynamic_atomic_model<configured_atomic_devstone, TIME>(atomic_name));
+                atomics_current_level.push_back(make_atomic_devstone(atomic_name));
             }
         }
         atomics_by_level[level] = atomics_current_level;
@@ -90,10 +84,10 @@ std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> create_HI_model(uint 
         if (level == 1) {
             Lcoupled_submodels= {devstone_atomic_L0_0};
             Lcoupled_eics = {
-                cadmium::dynamic::translate::make_EIC<coupled_in_port, devstone_atomic_defs::in>("devstone_atomic_L0_0")
+                cadmium::dynamic::translate::make_EIC<coupledHI_in_port, devstone_atomic_defs::in>("devstone_atomic_L0_0")
             };
             Lcoupled_eocs = {
-              cadmium::dynamic::translate::make_EOC<devstone_atomic_defs::out,coupled_out_port>("devstone_atomic_L0_0")
+              cadmium::dynamic::translate::make_EOC<devstone_atomic_defs::out,coupledHI_out_port>("devstone_atomic_L0_0")
             };
         } else {
             std::shared_ptr<cadmium::dynamic::modeling::model> coupled_prev_level = coupleds_by_level[level - 1];
@@ -101,13 +95,13 @@ std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> create_HI_model(uint 
             Lcoupled_submodels = { coupled_prev_level };
 
             Lcoupled_eics = {
-                cadmium::dynamic::translate::make_EIC<coupled_in_port, coupled_in_port>(
+                cadmium::dynamic::translate::make_EIC<coupledHI_in_port, coupledHI_in_port>(
                     coupled_prev_level.get()->get_id()
                 )
             };
 
             Lcoupled_eocs = {
-                cadmium::dynamic::translate::make_EOC<coupled_out_port, coupled_out_port>(
+                cadmium::dynamic::translate::make_EOC<coupledHI_out_port, coupledHI_out_port>(
                     coupled_prev_level.get()->get_id()
                 )
             };
@@ -115,7 +109,7 @@ std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> create_HI_model(uint 
                 auto atomic = atomics_by_level[level - 1][i];
                 Lcoupled_submodels.push_back(atomic);
                 Lcoupled_eics.push_back(
-                    cadmium::dynamic::translate::make_EIC<coupled_in_port, devstone_atomic_defs::in>(atomic.get()->get_id())
+                    cadmium::dynamic::translate::make_EIC<coupledHI_in_port, devstone_atomic_defs::in>(atomic.get()->get_id())
                 );
                 if(i < atomics_by_level[level - 1].size()- 1 ) { // skip last iteration
                     auto next_atomic = atomics_by_level[level - 1][i+1];
@@ -149,7 +143,7 @@ std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> create_HI_model(uint 
     cadmium::dynamic::modeling::EICs TOP_eics = {};
     cadmium::dynamic::modeling::EOCs TOP_eocs = {};
     cadmium::dynamic::modeling::ICs TOP_ics = {
-        cadmium::dynamic::translate::make_IC<devstone_event_reader_defs::out,coupled_in_port>("devstone_event_reader1",last_level_coupled.get()->get_id())
+        cadmium::dynamic::translate::make_IC<devstone_event_reader_defs::out,coupledHI_in_port>("devstone_event_reader1",last_level_coupled.get()->get_id())
     };
     std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> TOP_coupled = std::make_shared<cadmium::dynamic::modeling::coupled<TIME>>(
      "TOP_coupled",

--- a/src/dynamic/HO_generator.cpp
+++ b/src/dynamic/HO_generator.cpp
@@ -42,33 +42,27 @@
 using TIME = float;
 
 // Ports for coupled models, we use the same in every level
-struct coupled_in_port1 : public cadmium::in_port<int>{};
-struct coupled_in_port2 : public cadmium::in_port<int>{};
-struct coupled_out_port1 : public cadmium::out_port<int>{};
-struct coupled_out_port2 : public cadmium::out_port<int>{};
-cadmium::dynamic::modeling::Ports coupled_in_ports = {typeid(coupled_in_port1), typeid(coupled_in_port2)};
-cadmium::dynamic::modeling::Ports coupled_out_ports = {typeid(coupled_out_port1), typeid(coupled_out_port2)};
+struct coupledHO_in_port1 : public cadmium::in_port<int>{};
+struct coupledHO_in_port2 : public cadmium::in_port<int>{};
+struct coupledHO_out_port1 : public cadmium::out_port<int>{};
+struct coupledHO_out_port2 : public cadmium::out_port<int>{};
 
-//A configured version of the devstone atomic, we use same configuration in every atomic.
-template<typename T>
-struct configured_atomic_devstone : devstone_atomic<T>{
-    configured_atomic_devstone(){
-        devstone_atomic<T>::period = 1;
-        devstone_atomic<T>::external_cycles = 100;
-        devstone_atomic<T>::internal_cycles = 100;
-    }
-};
-
-
-std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> create_HO_model(uint width, uint depth) {
+std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> create_HO_model(
+        uint width, uint depth, int ext_cycles, int int_cycles, TIME time_advance) {
     // Creates the HO model with the passed parameters
     // Returns a shared_ptr to the TOP model
 
+    auto make_atomic_devstone = [&ext_cycles, &int_cycles, &time_advance](std::string model_id) -> std::shared_ptr<cadmium::dynamic::modeling::model> {
+        return cadmium::dynamic::translate::make_dynamic_atomic_model<devstone_atomic, TIME>(model_id, ext_cycles, int_cycles, time_advance);
+    };
     //Level 0 has always a single model
-    std::shared_ptr<cadmium::dynamic::modeling::model> devstone_atomic_L0_0 = cadmium::dynamic::translate::make_dynamic_atomic_model<configured_atomic_devstone, TIME>("devstone_atomic_L0_0");
+    std::shared_ptr<cadmium::dynamic::modeling::model> devstone_atomic_L0_0 = make_atomic_devstone("devstone_atomic_L0_0");
 
     std::unordered_map<int, cadmium::dynamic::modeling::Models> atomics_by_level;
     std::unordered_map<int, std::shared_ptr<cadmium::dynamic::modeling::model>> coupleds_by_level;
+
+    cadmium::dynamic::modeling::Ports coupled_in_ports = {typeid(coupledHO_in_port1), typeid(coupledHO_in_port2)};
+    cadmium::dynamic::modeling::Ports coupled_out_ports = {typeid(coupledHO_out_port1), typeid(coupledHO_out_port2)};
 
     for (int level=1; level <= depth; level++) {
 
@@ -78,7 +72,7 @@ std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> create_HO_model(uint 
             //Last level does not have atomics
             for(int idx_atomic=0; idx_atomic < width-1; idx_atomic++) {
                 std::string atomic_name = "devstone_atomic_L" + std::to_string(level) + "_" + std::to_string(idx_atomic);
-                atomics_current_level.push_back(cadmium::dynamic::translate::make_dynamic_atomic_model<configured_atomic_devstone, TIME>(atomic_name));
+                atomics_current_level.push_back(make_atomic_devstone(atomic_name));
             }
         }
         atomics_by_level[level] = atomics_current_level;
@@ -92,10 +86,10 @@ std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> create_HO_model(uint 
         if (level == 1) {
             Lcoupled_submodels= {devstone_atomic_L0_0};
             Lcoupled_eics = {
-                cadmium::dynamic::translate::make_EIC<coupled_in_port1, devstone_atomic_defs::in>("devstone_atomic_L0_0")
+                cadmium::dynamic::translate::make_EIC<coupledHO_in_port1, devstone_atomic_defs::in>("devstone_atomic_L0_0")
             };
             Lcoupled_eocs = {
-              cadmium::dynamic::translate::make_EOC<devstone_atomic_defs::out,coupled_out_port1>("devstone_atomic_L0_0")
+              cadmium::dynamic::translate::make_EOC<devstone_atomic_defs::out,coupledHO_out_port1>("devstone_atomic_L0_0")
             };
         } else {
             std::shared_ptr<cadmium::dynamic::modeling::model> coupled_prev_level = coupleds_by_level[level - 1];
@@ -103,16 +97,16 @@ std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> create_HO_model(uint 
             Lcoupled_submodels = { coupled_prev_level };
 
             Lcoupled_eics = {
-                cadmium::dynamic::translate::make_EIC<coupled_in_port1, coupled_in_port1>(
+                cadmium::dynamic::translate::make_EIC<coupledHO_in_port1, coupledHO_in_port1>(
                     coupled_prev_level.get()->get_id()
                 ),
-                cadmium::dynamic::translate::make_EIC<coupled_in_port1, coupled_in_port2>(
+                cadmium::dynamic::translate::make_EIC<coupledHO_in_port1, coupledHO_in_port2>(
                     coupled_prev_level.get()->get_id()
                 )
             };
 
             Lcoupled_eocs = {
-                cadmium::dynamic::translate::make_EOC<coupled_out_port1, coupled_out_port1>(
+                cadmium::dynamic::translate::make_EOC<coupledHO_out_port1, coupledHO_out_port1>(
                     coupled_prev_level.get()->get_id()
                 )
             };
@@ -120,10 +114,10 @@ std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> create_HO_model(uint 
                 auto atomic = atomics_by_level[level - 1][i];
                 Lcoupled_submodels.push_back(atomic);
                 Lcoupled_eics.push_back(
-                    cadmium::dynamic::translate::make_EIC<coupled_in_port2, devstone_atomic_defs::in>(atomic.get()->get_id())
+                    cadmium::dynamic::translate::make_EIC<coupledHO_in_port2, devstone_atomic_defs::in>(atomic.get()->get_id())
                 );
                 Lcoupled_eocs.push_back(
-                    cadmium::dynamic::translate::make_EOC<devstone_atomic_defs::out, coupled_out_port2>(atomic.get()->get_id())
+                    cadmium::dynamic::translate::make_EOC<devstone_atomic_defs::out, coupledHO_out_port2>(atomic.get()->get_id())
                 );
                 if(i < atomics_by_level[level - 1].size()- 1 ) { // skip last iteration
                     auto next_atomic = atomics_by_level[level - 1][i+1];
@@ -157,8 +151,8 @@ std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> create_HO_model(uint 
     cadmium::dynamic::modeling::EICs TOP_eics = {};
     cadmium::dynamic::modeling::EOCs TOP_eocs = {};
     cadmium::dynamic::modeling::ICs TOP_ics = {
-        cadmium::dynamic::translate::make_IC<devstone_event_reader_defs::out,coupled_in_port1>("devstone_event_reader1",last_level_coupled.get()->get_id()),
-        cadmium::dynamic::translate::make_IC<devstone_event_reader_defs::out,coupled_in_port2>("devstone_event_reader1",last_level_coupled.get()->get_id())
+        cadmium::dynamic::translate::make_IC<devstone_event_reader_defs::out,coupledHO_in_port1>("devstone_event_reader1",last_level_coupled.get()->get_id()),
+        cadmium::dynamic::translate::make_IC<devstone_event_reader_defs::out,coupledHO_in_port2>("devstone_event_reader1",last_level_coupled.get()->get_id())
     };
     std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> TOP_coupled = std::make_shared<cadmium::dynamic::modeling::coupled<TIME>>(
      "TOP_coupled",

--- a/test/cadmium_dynamic_LI_test.cpp
+++ b/test/cadmium_dynamic_LI_test.cpp
@@ -41,7 +41,7 @@ namespace bdata = boost::unit_test::data;
 BOOST_AUTO_TEST_SUITE( cadmium_dynamic_LI_test_suite)
 
 BOOST_DATA_TEST_CASE( top_level_has_two_models_test, bdata::xrange(2,12,3) * bdata::xrange(2,12,3), W, D ){
-    std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> TOP_coupled = create_LI_model(W, D);
+    std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> TOP_coupled = create_LI_model(W, D, 100, 100, 1);
     pt::ptree tree = to_prop_tree(TOP_coupled);
 
     auto TOP_submodels = tree.get_child("models");
@@ -54,7 +54,7 @@ BOOST_DATA_TEST_CASE( top_level_has_two_models_test, bdata::xrange(2,12,3) * bda
 }
 
 BOOST_DATA_TEST_CASE( top_level_has_an_IC_test, bdata::xrange(2,12,3) * bdata::xrange(2,12,3), W, D ){
-    std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> TOP_coupled = create_LI_model(W, D);
+    std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> TOP_coupled = create_LI_model(W, D, 100, 100, 1);
     pt::ptree tree = to_prop_tree(TOP_coupled);
     BOOST_CHECK_EQUAL(tree.get_child("ic").size(), 1);
     BOOST_CHECK_EQUAL(tree.get<std::string>("ic..from_model"), "devstone_event_reader1");
@@ -62,7 +62,7 @@ BOOST_DATA_TEST_CASE( top_level_has_an_IC_test, bdata::xrange(2,12,3) * bdata::x
 }
 
 BOOST_DATA_TEST_CASE( coupled_from_L1_has_1_submodel_and_its_atomic, bdata::xrange(2,12,3) * bdata::xrange(2,12,3), W, D ){
-    std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> TOP_coupled = create_LI_model(W, D);
+    std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> TOP_coupled = create_LI_model(W, D, 100, 100, 1);
     pt::ptree tree = to_prop_tree(TOP_coupled);
     auto models = tree.get_child("models");
     pt::ptree::iterator it_coupled;
@@ -78,7 +78,7 @@ BOOST_DATA_TEST_CASE( coupled_from_L1_has_1_submodel_and_its_atomic, bdata::xran
 }
 
 BOOST_DATA_TEST_CASE( coupled_models_from_l2_have_W_submodels, bdata::xrange(2,12,3) * bdata::xrange(2,12,3), W, D ){
-    std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> TOP_coupled = create_LI_model(W, D);
+    std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> TOP_coupled = create_LI_model(W, D, 100, 100, 1);
     pt::ptree tree = to_prop_tree(TOP_coupled);
     auto models = tree.get_child("models");
     for (int level=D; level >= 2; level--) {
@@ -95,7 +95,7 @@ BOOST_DATA_TEST_CASE( coupled_models_from_l2_have_W_submodels, bdata::xrange(2,1
 }
 
 BOOST_DATA_TEST_CASE( coupled_models_have_one_input_and_one_output, bdata::xrange(2,12,3) * bdata::xrange(2,12,3), W, D ){
-    std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> TOP_coupled = create_LI_model(W, D);
+    std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> TOP_coupled = create_LI_model(W, D, 100, 100, 1);
     pt::ptree tree = to_prop_tree(TOP_coupled);
     auto models = tree.get_child("models");
     for (int level=D; level >= 1; level--) {
@@ -114,7 +114,7 @@ BOOST_DATA_TEST_CASE( coupled_models_have_one_input_and_one_output, bdata::xrang
 
 
 BOOST_DATA_TEST_CASE( coupled_models_have_input_connected_to_all_submodels, bdata::xrange(2,12,3) * bdata::xrange(2,12,3), W, D ){
-    std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> TOP_coupled = create_LI_model(W, D);
+    std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> TOP_coupled = create_LI_model(W, D, 100, 100, 1);
     pt::ptree tree = to_prop_tree(TOP_coupled);
     auto models = tree.get_child("models");
     for (int level=D; level >= 1; level--) {
@@ -149,7 +149,7 @@ BOOST_DATA_TEST_CASE( coupled_models_have_input_connected_to_all_submodels, bdat
 }
 
 BOOST_DATA_TEST_CASE( coupled_models_have_coupled_only_coupled_child_connected_to_output, bdata::xrange(2,12,3) * bdata::xrange(2,12,3), W, D ){
-    std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> TOP_coupled = create_LI_model(W, D);
+    std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> TOP_coupled = create_LI_model(W, D, 100, 100, 1);
     pt::ptree tree = to_prop_tree(TOP_coupled);
     auto models = tree.get_child("models");
 


### PR DESCRIPTION
The command to execute cadmium dynamic devstone models from the terminal was created (src/cadmium-dynamic-devstone.cpp).

Changes were made in each dynamic model (LI, HI, HO, HOmod) to pass external cycles, internal cycles and time advance as a model parameter. 